### PR TITLE
[8.0][FIX] delivery_carrier_tnt: Picking write must use @api.multi

### DIFF
--- a/delivery_carrier_tnt/model/stock.py
+++ b/delivery_carrier_tnt/model/stock.py
@@ -105,11 +105,12 @@ class StockPicking(models.Model):
             res.carrier_id_change()
         return res
 
-    @api.one
+    @api.multi
     def write(self, vals):
         res = super(StockPicking, self).write(vals)
         if 'carrier_id' in vals:
-            self.carrier_id_change()
+            for picking in self:
+                picking.carrier_id_change()
         return res
 
     def _get_tnt_services(self):


### PR DESCRIPTION
The write method should be decorated with @api.multi so it can return
True instead of a list of bools.